### PR TITLE
Include the algorithm lib to icount

### DIFF
--- a/notebook/mem/icount.cpp
+++ b/notebook/mem/icount.cpp
@@ -4,6 +4,7 @@
 #include <limits>
 #include <atomic>
 #include <vector>
+#include <algorithm>
 #include <iostream>
 
 template <class T>


### PR DESCRIPTION
According to [cppreference](https://en.cppreference.com/w/cpp/algorithm), the `copy_n` is defined in `algorithm` header, we have to include it otherwise we have compilation error (in ubuntu 18.04).