### PR TITLE
Do not say that type detection must be done during runtime

### DIFF
--- a/notebook/20au_nctu/04_cpp/cpp.ipynb
+++ b/notebook/20au_nctu/04_cpp/cpp.ipynb
@@ -1439,7 +1439,7 @@
    "source": [
     "# Polymorphism\n",
     "\n",
-    "In C++, when a class has any member function that is virtual, it is polymorphic.  C++ detects the type of the polymorphic object in runtime, and use the type information to find the associarted member function."
+    "In C++, when a class has any member function that is virtual, it is polymorphic.  C++ compiler knows the object is polymorphic, and uses the type information to find the associarted member function in runtime."
    ]
   },
   {

--- a/notebook/20au_nctu/04_cpp/cpp_bare.ipynb
+++ b/notebook/20au_nctu/04_cpp/cpp_bare.ipynb
@@ -1174,7 +1174,7 @@
    "source": [
     "# Polymorphism\n",
     "\n",
-    "In C++, when a class has any member function that is virtual, it is polymorphic.  C++ detects the type of the polymorphic object in runtime, and use the type information to find the associarted member function."
+    "In C++, when a class has any member function that is virtual, it is polymorphic.  C++ compiler knows the object is polymorphic, and uses the type information to find the associarted member function in runtime."
    ]
   },
   {


### PR DESCRIPTION
This is to address the issue #24 raised by @Naetw.

I think it's good to not explicitly say the compiler detects the type during runtime.  The compiler may choose to do it during runtime, but for simple scenarios, it knows what type to use.  Runtime operations happen but they do not necessarily happen for type checking.