### PR TITLE
Fix typos in 02_engineering, 03_numpy, 04_cpp

### DIFF
--- a/notebook/20au_nctu/02_engineering/engineering.ipynb
+++ b/notebook/20au_nctu/02_engineering/engineering.ipynb
@@ -39,7 +39,7 @@
    "source": [
     "# Bash scripting\n",
     "\n",
-    "Shell script is the most common way for automation.  A shell is responsible for taking commands from users.  Every operating system provides shells.  Because of the ubiqitous Linux, `bash` becomes the most popular shell.  A bash shell script should work on almost all computer systems.\n",
+    "Shell script is the most common way for automation.  A shell is responsible for taking commands from users.  Every operating system provides shells.  Because of the ubiquitous Linux, `bash` becomes the most popular shell.  A bash shell script should work on almost all computer systems.\n",
     "\n",
     "Here I'll introduce some useful tricks for scripting bash."
    ]
@@ -120,7 +120,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Variables are essential in programming langauges.  Variables in bash do not have types, but there are two kinds of variables distinguished by their scopes.  One is the _shell variable_, which lives in the current shell.  The other is the _environment variable_, which is also visible in child processes.\n",
+    "Variables are essential in programming languages.  Variables in bash do not have types, but there are two kinds of variables distinguished by their scopes.  One is the _shell variable_, which lives in the current shell.  The other is the _environment variable_, which is also visible in child processes.\n",
     "\n",
     "```bash\n",
     "shell_var=\"shell_value\"\n",
@@ -849,7 +849,7 @@
     "\t$(CXX) -c $< -o $@\n",
     "```\n",
     "\n",
-    "`%` in the target will match any non-empty characters, and it is expanded in the prerequisite.  Thus, the `Makefile` will become much simpler.  And there's fewer places for mistakes:\n",
+    "`%` in the target will match any non-empty characters, and it is expanded in the prerequisite.  Thus, the `Makefile` will become much simpler.  And there are fewer places for mistakes:\n",
     "\n",
     "```\n",
     "CXX = g++\n",
@@ -989,7 +989,7 @@
     "echo \"NP may be set to $NP\"\n",
     "```\n",
     "\n",
-    "As the software grows, such simple conditional statements fail to handle the complexity.  It applies to both shell scripts and make files.  We need a dedicated tool for orchestrating the build processs.  Cmake is such a tool."
+    "As the software grows, such simple conditional statements fail to handle the complexity.  It applies to both shell scripts and make files.  We need a dedicated tool for orchestrating the build process.  Cmake is such a tool."
    ]
   },
   {
@@ -1000,7 +1000,7 @@
     }
    },
    "source": [
-    "Although it has \"make\" in the name, cmake is _not_ a variant of make.  It requires its own configuration file, called `CMakeLists.txt`.  On Linux, we usually let cmake to generate GNU make files, and then run make to build the software.  This is a so-called two-stage building process.  Cmake provides many helpers so that we may relatively easily configure the real build commands to deal with compiler flags, library and executable file names, and third-party librarires (dependencies).\n",
+    "Although it has \"make\" in the name, cmake is _not_ a variant of make.  It requires its own configuration file, called `CMakeLists.txt`.  On Linux, we usually let cmake to generate GNU make files, and then run make to build the software.  This is a so-called two-stage building process.  Cmake provides many helpers so that we may relatively easily configure the real build commands to deal with compiler flags, library and executable file names, and third-party libraries (dependencies).\n",
     "\n",
     "It is easy to let cmake use a separate build directory (it's the default behavior); the built files will be in a different directory from the source tree.  In this way, a single source tree may easily produce multiple binary trees.\n",
     "\n",
@@ -1066,7 +1066,7 @@
    "source": [
     "## Add a custom option\n",
     "\n",
-    "Cmake allows to add any custom option that is consumed from the command line.  For example, a new `DEBUG_SYMBOL` optiona can be added by the following cmake list code:\n",
+    "Cmake allows to add any custom option that is consumed from the command line.  For example, a new `DEBUG_SYMBOL` option can be added by the following cmake list code:\n",
     "\n",
     "```\n",
     "option(DEBUG_SYMBOL \"add debug information\" ON)\n",
@@ -1093,7 +1093,7 @@
    "source": [
     "# Git version control system\n",
     "\n",
-    "Version control system (VCS), which is also called source control managerment (SCM), is essential for programmers to engineer software.  There are only two things that programmers may engineer: the contents in source files, and the locations of them.  VCS is to tool to track their changes.\n",
+    "Version control system (VCS), which is also called source control management (SCM), is essential for programmers to engineer software.  There are only two things that programmers may engineer: the contents in source files, and the locations of them.  VCS is to tool to track their changes.\n",
     "\n",
     "Git (https://git-scm.com) is a popular VCS.  Created in 2005, it's a fairly young tool, while the history of VCS is at least 3 decades.  There are other tools for version control, but the popularity of git makes it a right tool for most scenarios."
    ]
@@ -1495,7 +1495,7 @@
     }
    },
    "source": [
-    "The synchronization is two-way: _push_ means to upload the local changes to the remote repository, and _pull_ downloads changes in the remote repository to local.  Git is reponsible for making sure to have no duplication of changes.\n",
+    "The synchronization is two-way: _push_ means to upload the local changes to the remote repository, and _pull_ downloads changes in the remote repository to local.  Git is responsible for making sure to have no duplication of changes.\n",
     "\n",
     "<img src=\"gitsync.png\" style=\"width: 80%; text-align: center;\">"
    ]
@@ -1619,11 +1619,11 @@
     "\n",
     "To err is human.  It's possible to be free from mistakes for 20 lines of code, but it is unrealistic to write 1,000 lines of code and expect no error.  There's a time I changed 200 lines of code without running a compiler while typing, at the end when the compiler builds without an error I fell out of my chair.\n",
     "\n",
-    "Thus, it's commonplace that programmers write \"experimental code\" during development.  Numerical code is no different.  Compared to other applications, numerical code tends to formulate a full problem for the experiment.  If the code is for a research project, the \"experiemnt\" itself may sometimes be the purpose.\n",
+    "Thus, it's commonplace that programmers write \"experimental code\" during development.  Numerical code is no different.  Compared to other applications, numerical code tends to formulate a full problem for the experiment.  If the code is for a research project, the \"experiment\" itself may sometimes be the purpose.\n",
     "\n",
     "For any application, the experimental code isn't much different from a test that will be used to check for regressions.  We may run the tests every time we change the code.  Thus, it's important to make the automatic tests fast.\n",
     "\n",
-    "Sensitivity is an equivalently important point for automatic tests.  We want the tests to capture regressions.  But we don't want they to fail with expected change of results and slow down the development.\n",
+    "Sensitivity is an equivalently important point for automatic tests.  We want the tests to capture regressions.  But we don't want them to fail with expected change of results and slow down the development.\n",
     "\n",
     "Automatic testing is a simple but important tool to improve coding productivity as well as code quality."
    ]
@@ -1986,7 +1986,7 @@
     "std::tuple<double, double> rotate(double rad, std::tuple<double, double> const & vec);\n",
     "```\n",
     "\n",
-    "When they merge their branches, it is obvious that their code won't work together.  Because the difference in signature, the discrepency is likely to be detected when they try to build the merged source code."
+    "When they merge their branches, it is obvious that their code won't work together.  Because the difference in signature, the discrepancy is likely to be detected when they try to build the merged source code."
    ]
   },
   {
@@ -1997,7 +1997,7 @@
     }
    },
    "source": [
-    "But oftentimes, compiler cannot tell the discrepency.  It can only be detected during runtime.\n",
+    "But oftentimes, compiler cannot tell the discrepancy.  It can only be detected during runtime.\n",
     "\n",
     "```cpp\n",
     "// the angle is in radian\n",
@@ -2049,7 +2049,7 @@
     "\n",
     "Software development takes a lot of communication.  This may be counter-intuitive to non-developers.  In an ideal, entropy free world, there is no cost to transfer information between minds, and collaboration is conducted without friction in communication.\n",
     "\n",
-    "In real world, communication doesn't work like that.  To develop useful software, the goal itself must be defined first.  This takes a lot of work and, intuitively, communication.  But after the goal is clarified and defined, we still need to spend a lot of efforts in commucation.\n",
+    "In real world, communication doesn't work like that.  To develop useful software, the goal itself must be defined first.  This takes a lot of work and, intuitively, communication.  But after the goal is clarified and defined, we still need to spend a lot of efforts in communication.\n",
     "\n",
     "You may be curious why?  Let's use our vector example again:\n",
     "\n",

--- a/notebook/20au_nctu/02_engineering/engineering_bare.ipynb
+++ b/notebook/20au_nctu/02_engineering/engineering_bare.ipynb
@@ -39,7 +39,7 @@
    "source": [
     "# Bash scripting\n",
     "\n",
-    "Shell script is the most common way for automation.  A shell is responsible for taking commands from users.  Every operating system provides shells.  Because of the ubiqitous Linux, `bash` becomes the most popular shell.  A bash shell script should work on almost all computer systems.\n",
+    "Shell script is the most common way for automation.  A shell is responsible for taking commands from users.  Every operating system provides shells.  Because of the ubiquitous Linux, `bash` becomes the most popular shell.  A bash shell script should work on almost all computer systems.\n",
     "\n",
     "Here I'll introduce some useful tricks for scripting bash."
    ]
@@ -120,7 +120,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Variables are essential in programming langauges.  Variables in bash do not have types, but there are two kinds of variables distinguished by their scopes.  One is the _shell variable_, which lives in the current shell.  The other is the _environment variable_, which is also visible in child processes.\n",
+    "Variables are essential in programming languages.  Variables in bash do not have types, but there are two kinds of variables distinguished by their scopes.  One is the _shell variable_, which lives in the current shell.  The other is the _environment variable_, which is also visible in child processes.\n",
     "\n",
     "```bash\n",
     "shell_var=\"shell_value\"\n",
@@ -677,7 +677,7 @@
     "\t$(CXX) -c $< -o $@\n",
     "```\n",
     "\n",
-    "`%` in the target will match any non-empty characters, and it is expanded in the prerequisite.  Thus, the `Makefile` will become much simpler.  And there's fewer places for mistakes:\n",
+    "`%` in the target will match any non-empty characters, and it is expanded in the prerequisite.  Thus, the `Makefile` will become much simpler.  And there are fewer places for mistakes:\n",
     "\n",
     "```\n",
     "CXX = g++\n",
@@ -788,7 +788,7 @@
     "echo \"NP may be set to $NP\"\n",
     "```\n",
     "\n",
-    "As the software grows, such simple conditional statements fail to handle the complexity.  It applies to both shell scripts and make files.  We need a dedicated tool for orchestrating the build processs.  Cmake is such a tool."
+    "As the software grows, such simple conditional statements fail to handle the complexity.  It applies to both shell scripts and make files.  We need a dedicated tool for orchestrating the build process.  Cmake is such a tool."
    ]
   },
   {
@@ -799,7 +799,7 @@
     }
    },
    "source": [
-    "Although it has \"make\" in the name, cmake is _not_ a variant of make.  It requires its own configuration file, called `CMakeLists.txt`.  On Linux, we usually let cmake to generate GNU make files, and then run make to build the software.  This is a so-called two-stage building process.  Cmake provides many helpers so that we may relatively easily configure the real build commands to deal with compiler flags, library and executable file names, and third-party librarires (dependencies).\n",
+    "Although it has \"make\" in the name, cmake is _not_ a variant of make.  It requires its own configuration file, called `CMakeLists.txt`.  On Linux, we usually let cmake to generate GNU make files, and then run make to build the software.  This is a so-called two-stage building process.  Cmake provides many helpers so that we may relatively easily configure the real build commands to deal with compiler flags, library and executable file names, and third-party libraries (dependencies).\n",
     "\n",
     "It is easy to let cmake use a separate build directory (it's the default behavior); the built files will be in a different directory from the source tree.  In this way, a single source tree may easily produce multiple binary trees.\n",
     "\n",
@@ -865,7 +865,7 @@
    "source": [
     "## Add a custom option\n",
     "\n",
-    "Cmake allows to add any custom option that is consumed from the command line.  For example, a new `DEBUG_SYMBOL` optiona can be added by the following cmake list code:\n",
+    "Cmake allows to add any custom option that is consumed from the command line.  For example, a new `DEBUG_SYMBOL` option can be added by the following cmake list code:\n",
     "\n",
     "```\n",
     "option(DEBUG_SYMBOL \"add debug information\" ON)\n",
@@ -892,7 +892,7 @@
    "source": [
     "# Git version control system\n",
     "\n",
-    "Version control system (VCS), which is also called source control managerment (SCM), is essential for programmers to engineer software.  There are only two things that programmers may engineer: the contents in source files, and the locations of them.  VCS is to tool to track their changes.\n",
+    "Version control system (VCS), which is also called source control management (SCM), is essential for programmers to engineer software.  There are only two things that programmers may engineer: the contents in source files, and the locations of them.  VCS is to tool to track their changes.\n",
     "\n",
     "Git (https://git-scm.com) is a popular VCS.  Created in 2005, it's a fairly young tool, while the history of VCS is at least 3 decades.  There are other tools for version control, but the popularity of git makes it a right tool for most scenarios."
    ]
@@ -1144,7 +1144,7 @@
     }
    },
    "source": [
-    "The synchronization is two-way: _push_ means to upload the local changes to the remote repository, and _pull_ downloads changes in the remote repository to local.  Git is reponsible for making sure to have no duplication of changes.\n",
+    "The synchronization is two-way: _push_ means to upload the local changes to the remote repository, and _pull_ downloads changes in the remote repository to local.  Git is responsible for making sure to have no duplication of changes.\n",
     "\n",
     "<img src=\"gitsync.png\" style=\"width: 80%; text-align: center;\">"
    ]
@@ -1268,11 +1268,11 @@
     "\n",
     "To err is human.  It's possible to be free from mistakes for 20 lines of code, but it is unrealistic to write 1,000 lines of code and expect no error.  There's a time I changed 200 lines of code without running a compiler while typing, at the end when the compiler builds without an error I fell out of my chair.\n",
     "\n",
-    "Thus, it's commonplace that programmers write \"experimental code\" during development.  Numerical code is no different.  Compared to other applications, numerical code tends to formulate a full problem for the experiment.  If the code is for a research project, the \"experiemnt\" itself may sometimes be the purpose.\n",
+    "Thus, it's commonplace that programmers write \"experimental code\" during development.  Numerical code is no different.  Compared to other applications, numerical code tends to formulate a full problem for the experiment.  If the code is for a research project, the \"experiment\" itself may sometimes be the purpose.\n",
     "\n",
     "For any application, the experimental code isn't much different from a test that will be used to check for regressions.  We may run the tests every time we change the code.  Thus, it's important to make the automatic tests fast.\n",
     "\n",
-    "Sensitivity is an equivalently important point for automatic tests.  We want the tests to capture regressions.  But we don't want they to fail with expected change of results and slow down the development.\n",
+    "Sensitivity is an equivalently important point for automatic tests.  We want the tests to capture regressions.  But we don't want them to fail with expected change of results and slow down the development.\n",
     "\n",
     "Automatic testing is a simple but important tool to improve coding productivity as well as code quality."
    ]
@@ -1594,7 +1594,7 @@
     "std::tuple<double, double> rotate(double rad, std::tuple<double, double> const & vec);\n",
     "```\n",
     "\n",
-    "When they merge their branches, it is obvious that their code won't work together.  Because the difference in signature, the discrepency is likely to be detected when they try to build the merged source code."
+    "When they merge their branches, it is obvious that their code won't work together.  Because the difference in signature, the discrepancy is likely to be detected when they try to build the merged source code."
    ]
   },
   {
@@ -1605,7 +1605,7 @@
     }
    },
    "source": [
-    "But oftentimes, compiler cannot tell the discrepency.  It can only be detected during runtime.\n",
+    "But oftentimes, compiler cannot tell the discrepancy.  It can only be detected during runtime.\n",
     "\n",
     "```cpp\n",
     "// the angle is in radian\n",
@@ -1657,7 +1657,7 @@
     "\n",
     "Software development takes a lot of communication.  This may be counter-intuitive to non-developers.  In an ideal, entropy free world, there is no cost to transfer information between minds, and collaboration is conducted without friction in communication.\n",
     "\n",
-    "In real world, communication doesn't work like that.  To develop useful software, the goal itself must be defined first.  This takes a lot of work and, intuitively, communication.  But after the goal is clarified and defined, we still need to spend a lot of efforts in commucation.\n",
+    "In real world, communication doesn't work like that.  To develop useful software, the goal itself must be defined first.  This takes a lot of work and, intuitively, communication.  But after the goal is clarified and defined, we still need to spend a lot of efforts in communication.\n",
     "\n",
     "You may be curious why?  Let's use our vector example again:\n",
     "\n",

--- a/notebook/20au_nctu/03_numpy/numpy.ipynb
+++ b/notebook/20au_nctu/03_numpy/numpy.ipynb
@@ -1661,7 +1661,7 @@
     "\n",
     "The other is to use code written by other people.  Especially in the early stage of development, we want to quickly see the results.  We may just use the results of other software.  We may directly incoporate the foreign (usually, also called \"third-party\") software, if the situation allows.  Otherwise, we can replace the quick prototype in a later phase.\n",
     "\n",
-    "In this lecture, I will introduce 4 useful tools for numerical analysis that you may use thoughout the course and your future work."
+    "In this lecture, I will introduce 4 useful tools for numerical analysis that you may use throughout the course and your future work."
    ]
   },
   {

--- a/notebook/20au_nctu/03_numpy/numpy_bare.ipynb
+++ b/notebook/20au_nctu/03_numpy/numpy_bare.ipynb
@@ -1229,7 +1229,7 @@
     "\n",
     "The other is to use code written by other people.  Especially in the early stage of development, we want to quickly see the results.  We may just use the results of other software.  We may directly incoporate the foreign (usually, also called \"third-party\") software, if the situation allows.  Otherwise, we can replace the quick prototype in a later phase.\n",
     "\n",
-    "In this lecture, I will introduce 4 useful tools for numerical analysis that you may use thoughout the course and your future work."
+    "In this lecture, I will introduce 4 useful tools for numerical analysis that you may use throughout the course and your future work."
    ]
   },
   {

--- a/notebook/20au_nctu/04_cpp/cpp.ipynb
+++ b/notebook/20au_nctu/04_cpp/cpp.ipynb
@@ -768,7 +768,7 @@
     "\n",
     "Single-precision floating-point value uses 32 bits (4 bytes).  The first 23 bits are fraction.  The following 8 bits are exponent.  The last (highest) bit is sign; 0 is positive while 1 is negative.  In C++, the type name is `float`.\n",
     "\n",
-    "Conisder a decimal number 2.75, which we use as an example to show how the get the fields.  Write it by using the base of 2:\n",
+    "Conisder a decimal number 2.75, which we use as an example to show how to get the fields.  Write it by using the base of 2:\n",
     "\n",
     "\\begin{align*}\n",
     "%\n",
@@ -794,7 +794,7 @@
     }
    },
    "source": [
-    "The floating-point value is usually inexact.  For example, `0.3`, although it is rational, cannot be exactly represented as a single-precision floating-point.  Because the single-precision is 2-based, you should not follow the arithmic intuition learned from the 10-based number system."
+    "The floating-point value is usually inexact.  For example, `0.3`, although it is rational, cannot be exactly represented as a single-precision floating-point.  Because the single-precision is 2-based, you should not follow the arithmetic intuition learned from the 10-based number system."
    ]
   },
   {
@@ -839,7 +839,7 @@
     "\n",
     "Double-precision floating-point value uses 64 bits (8 bytes).  The first 52 bits are fraction.  The following 11 bits are exponent.  The last (highest) bit is sign; 0 is positive while 1 is negative.  In C++, the type name is `double`.\n",
     "\n",
-    "Use the same example of 2.75 for the double-precision floating-point.  Write $2.75 = (1.011)_2 \\times 2^1$.  The exponent bias for single-precision floating-point is 1023 ($(\\mathtt{11 \\, 1111 \\, 1111})_2$).  The bit fields are:\n",
+    "Use the same example of 2.75 for the double-precision floating-point.  Write $2.75 = (1.011)_2 \\times 2^1$.  The exponent bias for double-precision floating-point is 1023 ($(\\mathtt{11 \\, 1111 \\, 1111})_2$).  The bit fields are:\n",
     "\n",
     "| sign (1 bit)   | exponent (11 bits)   | fraction (52 bits)                                                 |\n",
     "|----------------|----------------------|--------------------------------------------------------------------|\n",
@@ -1292,7 +1292,7 @@
    "source": [
     "# Constructor and destructor\n",
     "\n",
-    "A constructor of a class is called when an object of the class is _instantiates_ (the _object_ can also be called an _instance_).  You may have as many constructors as you like.  There are special constructors that the compiler provides even if you don't.  The most essential one is the _default constructor_.  It does not have any argument, and is called when you declare a variable of the class.\n",
+    "A constructor of a class is called when an object of the class is _instantiated_ (the _object_ can also be called an _instance_).  You may have as many constructors as you like.  There are special constructors that the compiler provides even if you don't.  The most essential one is the _default constructor_.  It does not have any argument, and is called when you declare a variable of the class.\n",
     "\n",
     "```cpp\n",
     "class Line // assume it possesses heavy resources\n",
@@ -1439,7 +1439,7 @@
    "source": [
     "# Polymorphism\n",
     "\n",
-    "In C++, when a class has any member function that is virtual, it is polymorphic.  C++ compiler knows the object is polymorphic, and uses the type information to find the associarted member function in runtime."
+    "In C++, when a class has any member function that is virtual, it is polymorphic.  C++ compiler knows the object is polymorphic, and uses the type information to find the associated member function in runtime."
    ]
   },
   {
@@ -1577,7 +1577,7 @@
    "source": [
     "# Curiously recursive template pattern (CRTP)\n",
     "\n",
-    "If we want to make a class hierarchy polymorphic without the runtime overhead, CRTP helps.  Usually the word polymorphism means _dynamic_ polymorphism, as we described in the previous section.  If the classes behave as polymorphic but all the type information is determined durint _compile_ time, it is called _static_ polymorphism.\n",
+    "If we want to make a class hierarchy polymorphic without the runtime overhead, CRTP helps.  Usually the word polymorphism means _dynamic_ polymorphism, as we described in the previous section.  If the classes behave as polymorphic but all the type information is determined during _compile_ time, it is called _static_ polymorphism.\n",
     "\n",
     "Static polymorphism has two major benefits (at the cost of being limited in compile time).  First is to not have runtime overhead.  The second is to avoid the memory overhead associated with virtual functions.  RTTI needs some information to determine types in runtime.  That is usually (if not always) accomplished by a virtual function table, which at least add one more word on _every_ polymorphic object.  For very small objects, like a resource handle, which usually occupies one or two words, it's a great overhead."
    ]

--- a/notebook/20au_nctu/04_cpp/cpp_bare.ipynb
+++ b/notebook/20au_nctu/04_cpp/cpp_bare.ipynb
@@ -597,7 +597,7 @@
     "\n",
     "Single-precision floating-point value uses 32 bits (4 bytes).  The first 23 bits are fraction.  The following 8 bits are exponent.  The last (highest) bit is sign; 0 is positive while 1 is negative.  In C++, the type name is `float`.\n",
     "\n",
-    "Conisder a decimal number 2.75, which we use as an example to show how the get the fields.  Write it by using the base of 2:\n",
+    "Conisder a decimal number 2.75, which we use as an example to show how to get the fields.  Write it by using the base of 2:\n",
     "\n",
     "\\begin{align*}\n",
     "%\n",
@@ -623,7 +623,7 @@
     }
    },
    "source": [
-    "The floating-point value is usually inexact.  For example, `0.3`, although it is rational, cannot be exactly represented as a single-precision floating-point.  Because the single-precision is 2-based, you should not follow the arithmic intuition learned from the 10-based number system."
+    "The floating-point value is usually inexact.  For example, `0.3`, although it is rational, cannot be exactly represented as a single-precision floating-point.  Because the single-precision is 2-based, you should not follow the arithmetic intuition learned from the 10-based number system."
    ]
   },
   {
@@ -655,7 +655,7 @@
     "\n",
     "Double-precision floating-point value uses 64 bits (8 bytes).  The first 52 bits are fraction.  The following 11 bits are exponent.  The last (highest) bit is sign; 0 is positive while 1 is negative.  In C++, the type name is `double`.\n",
     "\n",
-    "Use the same example of 2.75 for the double-precision floating-point.  Write $2.75 = (1.011)_2 \\times 2^1$.  The exponent bias for single-precision floating-point is 1023 ($(\\mathtt{11 \\, 1111 \\, 1111})_2$).  The bit fields are:\n",
+    "Use the same example of 2.75 for the double-precision floating-point.  Write $2.75 = (1.011)_2 \\times 2^1$.  The exponent bias for double-precision floating-point is 1023 ($(\\mathtt{11 \\, 1111 \\, 1111})_2$).  The bit fields are:\n",
     "\n",
     "| sign (1 bit)   | exponent (11 bits)   | fraction (52 bits)                                                 |\n",
     "|----------------|----------------------|--------------------------------------------------------------------|\n",
@@ -1042,7 +1042,7 @@
    "source": [
     "# Constructor and destructor\n",
     "\n",
-    "A constructor of a class is called when an object of the class is _instantiates_ (the _object_ can also be called an _instance_).  You may have as many constructors as you like.  There are special constructors that the compiler provides even if you don't.  The most essential one is the _default constructor_.  It does not have any argument, and is called when you declare a variable of the class.\n",
+    "A constructor of a class is called when an object of the class is _instantiated_ (the _object_ can also be called an _instance_).  You may have as many constructors as you like.  There are special constructors that the compiler provides even if you don't.  The most essential one is the _default constructor_.  It does not have any argument, and is called when you declare a variable of the class.\n",
     "\n",
     "```cpp\n",
     "class Line // assume it possesses heavy resources\n",
@@ -1174,7 +1174,7 @@
    "source": [
     "# Polymorphism\n",
     "\n",
-    "In C++, when a class has any member function that is virtual, it is polymorphic.  C++ compiler knows the object is polymorphic, and uses the type information to find the associarted member function in runtime."
+    "In C++, when a class has any member function that is virtual, it is polymorphic.  C++ compiler knows the object is polymorphic, and uses the type information to find the associated member function in runtime."
    ]
   },
   {
@@ -1279,7 +1279,7 @@
    "source": [
     "# Curiously recursive template pattern (CRTP)\n",
     "\n",
-    "If we want to make a class hierarchy polymorphic without the runtime overhead, CRTP helps.  Usually the word polymorphism means _dynamic_ polymorphism, as we described in the previous section.  If the classes behave as polymorphic but all the type information is determined durint _compile_ time, it is called _static_ polymorphism.\n",
+    "If we want to make a class hierarchy polymorphic without the runtime overhead, CRTP helps.  Usually the word polymorphism means _dynamic_ polymorphism, as we described in the previous section.  If the classes behave as polymorphic but all the type information is determined during _compile_ time, it is called _static_ polymorphism.\n",
     "\n",
     "Static polymorphism has two major benefits (at the cost of being limited in compile time).  First is to not have runtime overhead.  The second is to avoid the memory overhead associated with virtual functions.  RTTI needs some information to determine types in runtime.  That is usually (if not always) accomplished by a virtual function table, which at least add one more word on _every_ polymorphic object.  For very small objects, like a resource handle, which usually occupies one or two words, it's a great overhead."
    ]


### PR DESCRIPTION
- 02_engineering
    - ubiqitous -> ubiquitous
    - langauges -> languages
    - there's -> there are
    - processs -> process
    - librarires -> libraries
    - optiona -> option
    - managerment -> management
    - reponsible -> responsible
    - experiemnt -> experiment
    - want they -> want them
    - discrepency -> discrepancy
    - commucation → communication
- 03_numpy
    - thoughout → throughout
- 04_cpp
    - how the get -> how to get
    - arithmic -> arithmetic
    - single-precision -> double-precision in Section "Double-precision"
    - _instantiates_ -> _instantiated_
    - associarted -> associated
    - durint -> during