### PR TITLE
Use .DEFAULT_GOAL to assign default target

### DIFF
--- a/notebook/20au_nctu/02_engineering/engineering.ipynb
+++ b/notebook/20au_nctu/02_engineering/engineering.ipynb
@@ -928,7 +928,7 @@
     "```\n",
     "# If the following two lines are commented out, the default target becomes hello.o.\n",
     ".PHONY: default\n",
-    "default: hello\n",
+    ".DEFAULT_GOAL = hello\n",
     "\n",
     "# Implicit rules will be skipped when searching for default.\n",
     "#%.o: %.cpp hello.hpp\n",


### PR DESCRIPTION
Useing .DEFAULT_GOAL can assign absolute default target no matter where this line located.